### PR TITLE
Add logic for selective stdout disabling, and disable noisy cases

### DIFF
--- a/lib/sshkit/sudo/backends/netssh.rb
+++ b/lib/sshkit/sudo/backends/netssh.rb
@@ -2,6 +2,18 @@ module SSHKit
   module Sudo
     module Backend
       module Netssh
+        # IMPORTANT! This logic has been implemented without an in-depth review of the whole logic.
+        #
+        # Ideally, we'd pass this to Sudo::Backend::Abstract, which would use it in execute_command!.
+        # The problem is that, apparently, this class' `execute_command!` is executed asynchronously,
+        # so there's no direct connection.
+        #
+        # Since this is a very narrow extension, it's ok to keep it and revisit only if further, significant,
+        # extensions are required.
+        #
+        SKIP_STDOUT_LOGGING_PATTERNS = [
+        ]
+
         private
         def execute_command!(cmd)
           output.log_command_start(cmd)
@@ -13,7 +25,8 @@ module SSHKit
               chan.exec cmd.to_command do |_ch, _success|
                 chan.on_data do |ch, data|
                   cmd.on_stdout(ch, data)
-                  output.log_command_data(cmd, :stdout, data)
+                  skip_stdout_logging = SKIP_STDOUT_LOGGING_PATTERNS.any? { |pattern| data =~ pattern }
+                  output.log_command_data(cmd, :stdout, data) unless skip_stdout_logging
                 end
                 chan.on_extended_data do |ch, _type, data|
                   cmd.on_stderr(ch, data)

--- a/lib/sshkit/sudo/backends/netssh.rb
+++ b/lib/sshkit/sudo/backends/netssh.rb
@@ -12,6 +12,9 @@ module SSHKit
         # extensions are required.
         #
         SKIP_STDOUT_LOGGING_PATTERNS = [
+          /^\r\n$/,
+          /^\[sudo\] password for /, # This removes context from the wrong password prompt, but it's
+                                     # a problem in our workflow.
         ]
 
         private


### PR DESCRIPTION
Disabled the noisy output:

- password prompt
- blank output (`\r\n`)

A detailed comment is provided in the main commit.