### PR TITLE
Simplify the Backend::Abstract overridde

### DIFF
--- a/lib/sshkit/sudo.rb
+++ b/lib/sshkit/sudo.rb
@@ -11,6 +11,6 @@ module SSHKit
     end
   end
 
-  Backend::Abstract.send(:include, ::SSHKit::Sudo::Backend::Abstract)
+  Backend::Abstract.send(:prepend, ::SSHKit::Sudo::Backend::Abstract)
   Backend::Netssh.send(:include, ::SSHKit::Sudo::Backend::Netssh)
 end

--- a/lib/sshkit/sudo/backends/abstract.rb
+++ b/lib/sshkit/sudo/backends/abstract.rb
@@ -2,22 +2,17 @@ module SSHKit
   module Sudo
     module Backend
       module Abstract
-        def sudo(*args)
-          execute!(:sudo, *args)
-        end
-
-        def execute!(*args)
-          options = args.extract_options!
-          options[:interaction_handler] ||= SSHKit::Sudo::InteractionHandler.new
-          create_command_and_execute!(args, options).success?
+        def capture(*args)
+          # To ensure that we clean out the sudo part when the results are returned,
+          # otherwise the commands will be corrupt.
+          #
+          super.gsub(/\[sudo\] password for \S+\:/, '')
         end
 
         private
-        def execute_command!(*args)
-          execute_command(*args)
-        end
 
-        def create_command_and_execute!(args, options)
+        def create_command_and_execute(args, options)
+          options[:interaction_handler] ||= SSHKit::Sudo::InteractionHandler.new
           command(args, options).tap { |cmd| execute_command!(cmd) }
         end
       end

--- a/lib/sshkit/sudo/version.rb
+++ b/lib/sshkit/sudo/version.rb
@@ -1,5 +1,5 @@
 module SSHKit
   module Sudo
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end


### PR DESCRIPTION
Since now we always use the sudo mode, we don't need alternate logic, so we can just patch the (two) core methods.